### PR TITLE
Use sklearn.cluster.KMeans for init

### DIFF
--- a/harmonypy/harmony.py
+++ b/harmonypy/harmony.py
@@ -17,8 +17,8 @@
 
 import pandas as pd
 import numpy as np
-# kmeans does not always return k centroids, but kmeans2 does
 from scipy.cluster.vq import kmeans2
+from sklearn.cluster import KMeans
 import logging
 
 # create logger
@@ -186,7 +186,12 @@ class Harmony(object):
 
     def init_cluster(self):
         # Start with cluster centroids
-        km_centroids, km_labels = kmeans2(self.Z_cos.T, self.K, minit='++')
+        logger.info("Computing initial centroids with sklearn.KMeans...")
+        model = KMeans(n_clusters=self.K, init='k-means++',
+                       n_init=10, max_iter=25)
+        model.fit(self.Z_cos.T)
+        km_centroids, km_labels = model.cluster_centers_, model.labels_
+        logger.info("sklearn.KMeans initialization complete.")
         self.Y = km_centroids.T
         # (1) Normalize
         self.Y = self.Y / np.linalg.norm(self.Y, ord=2, axis=0)

--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires='>=3.6',
-    install_requires=['pandas','numpy','scipy'],
+    install_requires=['pandas','numpy','scipy', 'scikit-learn'],
 )


### PR DESCRIPTION
This PR replaces scipy KMeans with scikit-learn version.

`scipy.cluster.vq.kmeans2` is slower than `sklearn.cluster.KMeans`. This has been discussed before in [scipy](https://github.com/scipy/scipy/issues/11877), but it seems the issue persists. Running the same snippet for [this toy 500x200 matrix](https://github.com/slowkow/harmonypy/files/10059667/data.csv.gz):

```python
import numpy as np
from sklearn.cluster import KMeans
from scipy.cluster.vq import kmeans2
import time as t

data = np.loadtxt('data.csv.gz')
duration = {'scipy': [], 'sklearn': []}
k_opts = np.arange(10, 201, 10)

for k in k_opts:
    s = t.time()
    centroid1, labels1 = kmeans2(data, k, minit='++', iter=10, thresh=1.e-4)
    duration['scipy'].append(t.time() - s)

    s = t.time()

    model = KMeans(n_clusters=k, init='k-means++', tol=1.e-4,
                   max_iter=10, n_init=1, verbose=0)
    model.fit(data)
    centroid2, labels2 = model.cluster_centers_, model.labels_
    duration['sklearn'].append(t.time() - s)

```
![image](https://user-images.githubusercontent.com/1301626/203135222-de96b9d7-6fef-4e77-9724-4a1f635ce73c.png)

Similar behavior has seen in other libraries:     https://hdbscan.readthedocs.io/en/latest/performance_and_scalability.html#comparison-of-high-performance-implementations
